### PR TITLE
match order of parameters to called function

### DIFF
--- a/cmd/reticulum-go/main.go
+++ b/cmd/reticulum-go/main.go
@@ -160,9 +160,9 @@ func NewReticulum(cfg *common.ReticulumConfig) (*Reticulum, error) {
 				name,
 				ifaceConfig.TargetHost,
 				ifaceConfig.TargetPort,
+				ifaceConfig.KISSFraming,
+				ifaceConfig.I2PTunneled,
 				ifaceConfig.Enabled,
-				true, // IN
-				true, // OUT
 			)
 		case "UDPInterface":
 			iface, err = interfaces.NewUDPInterface(


### PR DESCRIPTION
Disclaimer: N00B in every sense of the word.  Feel free to ignore.


The parameter order for https://github.com/Sudo-Ivan/Reticulum-Go/blob/fed33aadffa0fd8aa279fa4c7f0eaa24a8f164e1/pkg/interfaces/tcp.go#L56 

mismatched these in https://github.com/Sudo-Ivan/Reticulum-Go/blob/fed33aadffa0fd8aa279fa4c7f0eaa24a8f164e1/cmd/reticulum-go/main.go#L159-L166 

so they were updated as:

```
iface, err = interfaces.NewTCPClientInterface(
				name,
				ifaceConfig.TargetHost,
				ifaceConfig.TargetPort,
				ifaceConfig.KISSFraming,
				ifaceConfig.I2PTunneled,
				ifaceConfig.Enabled,
			)
```


## Contributing Requirements:
### gosec 
```
Reticulum-Go/pkg/link/link.go:609] - G407 (CWE-1204): Use of hardcoded IV/nonce for encryption by passing hardcoded slice/array (Confidence: HIGH, Severity: HIGH)
    608: 
  > 609:        mode := cipher.NewCBCDecrypter(block, iv)
    610:        plaintext := make([]byte, len(ciphertext))

Reticulum-Go/pkg/identity/identity.go:364] - G407 (CWE-1204): Use of hardcoded IV/nonce for encryption by passing hardcoded slice/array (Confidence: HIGH, Severity: HIGH)
    363: 
  > 364:        mode := cipher.NewCBCDecrypter(block, iv)
    365:        plaintext := make([]byte, len(actualCiphertext))

Reticulum-Go/pkg/cryptography/aes.go:85] - G407 (CWE-1204): Use of hardcoded IV/nonce for encryption by passing hardcoded slice/array (Confidence: HIGH, Severity: HIGH)
    84:         // Decrypt the data.
  > 85:         mode := cipher.NewCBCDecrypter(block, iv)
    86:         plaintext := make([]byte, len(ciphertext))
```
I only know enough crypto to stay away from implementing it.

### go fmt
Files outside of my edits were modified so these changes were discarded.